### PR TITLE
Handle optional objects in ProximityLookup

### DIFF
--- a/entities/game/proximity_lookup.py
+++ b/entities/game/proximity_lookup.py
@@ -39,17 +39,27 @@ class ProximityLookup:
         enemy_robots: Optional[Dict[int, Robot]],
         ball: Optional[Ball],
     ) -> Tuple[List[ObjectKey], np.ndarray]:
-        object_keys = []
-        point_array = []
-        for robot in friendly_robots.values():
-            object_keys.append(ObjectKey(TeamType.FRIENDLY, ObjectType.ROBOT, robot.id))
-            point_array.append(robot.p.to_array())
-        for robot in enemy_robots.values():
-            object_keys.append(ObjectKey(TeamType.ENEMY, ObjectType.ROBOT, robot.id))
-            point_array.append(robot.p.to_array())
+        object_keys: List[ObjectKey] = []
+        point_array: List[np.ndarray] = []
+
+        if friendly_robots:
+            for robot in friendly_robots.values():
+                object_keys.append(
+                    ObjectKey(TeamType.FRIENDLY, ObjectType.ROBOT, robot.id)
+                )
+                point_array.append(robot.p.to_array())
+
+        if enemy_robots:
+            for robot in enemy_robots.values():
+                object_keys.append(
+                    ObjectKey(TeamType.ENEMY, ObjectType.ROBOT, robot.id)
+                )
+                point_array.append(robot.p.to_array())
+
         if ball:
             object_keys.append(ObjectKey(TeamType.NEUTRAL, ObjectType.BALL, 0))
             point_array.append(ball.p.to_2d().to_array())
+
         return object_keys, np.array(point_array)
 
     def _build_proximity_matrix(self, point_array: np.ndarray) -> np.ndarray:
@@ -106,7 +116,7 @@ class ProximityLookup:
     def closest_to_ball(
         self, team_type_filter: Optional[TeamType] = None
     ) -> Tuple[Optional[ObjectKey], float]:
-        if self.object_keys[-1].object_type != ObjectType.BALL:
+        if not self.object_keys or self.object_keys[-1].object_type != ObjectType.BALL:
             warnings.warn(
                 "Invalid closest_to_ball query: cannot find ball in proximity lookup."
             )

--- a/entities/tests/test_proximity_lookup.py
+++ b/entities/tests/test_proximity_lookup.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+from entities.game.proximity_lookup import ProximityLookup
+from entities.game.robot import Robot
+from entities.game.ball import Ball
+from entities.data.vector import Vector2D, Vector3D
+
+
+def test_proximity_lookup_handles_none_inputs():
+    lookup = ProximityLookup(friendly_robots=None, enemy_robots=None, ball=None)
+    obj, dist = lookup.closest_to_ball()
+    assert obj is None
+    assert np.isinf(dist)
+
+
+def test_proximity_lookup_with_no_ball():
+    robots = {
+        1: Robot(
+            id=1,
+            is_friendly=True,
+            has_ball=False,
+            p=Vector2D(0, 0),
+            v=Vector2D(0, 0),
+            a=Vector2D(0, 0),
+            orientation=0,
+        )
+    }
+    lookup = ProximityLookup(friendly_robots=robots, enemy_robots=None, ball=None)
+    obj, dist = lookup.closest_to_ball()
+    assert obj is None
+    assert np.isinf(dist)


### PR DESCRIPTION
## Summary
- Avoid errors when ProximityLookup is created without robots or ball
- Guard against missing ball queries
- Add regression tests for empty inputs

## Testing
- `pytest entities/tests/test_proximity_lookup.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'entities.game.game_object', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6895b8b143248326b6dea41edc18bc9d